### PR TITLE
fix: removed zone identifiers for windows compatibility

### DIFF
--- a/media/images/DALL_E_2024-01-01_12.58.13_-_A_cartoon-style_emote_with_an_anime_influence__showing_the__Ducktronaut___an_astronaut-themed_rubber_duck__looking_extremely_worried._The_duck_has_a_y-removebg-preview (1).png:Zone.Identifier
+++ b/media/images/DALL_E_2024-01-01_12.58.13_-_A_cartoon-style_emote_with_an_anime_influence__showing_the__Ducktronaut___an_astronaut-themed_rubber_duck__looking_extremely_worried._The_duck_has_a_y-removebg-preview (1).png:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.remove.bg/
-LastWriterPackageFamilyName=Microsoft.Windows.Photos_8wekyb3d8bbwe

--- a/media/images/DALL_E_2024-01-03_02.07.14_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__giving_a_salute._The_Ducktronaut_has_a_yellow_body__is_wearing_a_white_space_-removebg-preview.png:Zone.Identifier
+++ b/media/images/DALL_E_2024-01-03_02.07.14_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__giving_a_salute._The_Ducktronaut_has_a_yellow_body__is_wearing_a_white_space_-removebg-preview.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.remove.bg/

--- a/media/images/DALL_E_2024-01-03_22.22.35_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__with_an_excited_expression_as_if_it_s_heading_to_the_moon._The_Ducktronaut_ha-removebg-preview.png:Zone.Identifier
+++ b/media/images/DALL_E_2024-01-03_22.22.35_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__with_an_excited_expression_as_if_it_s_heading_to_the_moon._The_Ducktronaut_ha-removebg-preview.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.remove.bg/

--- a/media/images/DALL_E_2024-01-07_03.39.11_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__designed_for_a_Twitch_mod._From_the_chest_up__the_Ducktronaut_has_a_yellow_bo-removebg-preview (1).png:Zone.Identifier
+++ b/media/images/DALL_E_2024-01-07_03.39.11_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__designed_for_a_Twitch_mod._From_the_chest_up__the_Ducktronaut_has_a_yellow_bo-removebg-preview (1).png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.remove.bg/

--- a/media/images/DALL_E_2024-01-07_23.44.56_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__looking_up_with_an_expression_that_says__d_aww_._Ducktronaut_has_a_yellow_bod-removebg-preview.png:Zone.Identifier
+++ b/media/images/DALL_E_2024-01-07_23.44.56_-_A_cartoon-style_emote_of__Ducktronaut___an_astronaut-themed_rubber_duck__looking_up_with_an_expression_that_says__d_aww_._Ducktronaut_has_a_yellow_bod-removebg-preview.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.remove.bg/

--- a/media/images/duckcheer.png:Zone.Identifier
+++ b/media/images/duckcheer.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.Windows.Photos_8wekyb3d8bbwe
-ZoneId=3

--- a/media/images/duckcry.png:Zone.Identifier
+++ b/media/images/duckcry.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.Windows.Photos_8wekyb3d8bbwe
-ZoneId=3

--- a/media/images/duckguitar.png:Zone.Identifier
+++ b/media/images/duckguitar.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.Windows.Photos_8wekyb3d8bbwe
-ZoneId=3

--- a/media/images/ducklaugh.png:Zone.Identifier
+++ b/media/images/ducklaugh.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.Windows.Photos_8wekyb3d8bbwe
-ZoneId=3

--- a/media/images/ducklove.png:Zone.Identifier
+++ b/media/images/ducklove.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.Windows.Photos_8wekyb3d8bbwe
-ZoneId=3

--- a/media/images/image_2024-01-04_111519539-removebg-preview.png:Zone.Identifier
+++ b/media/images/image_2024-01-04_111519539-removebg-preview.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.remove.bg/

--- a/wan2.2-animate-replace/README.md
+++ b/wan2.2-animate-replace/README.md
@@ -1,0 +1,71 @@
+# Wan2.2 Animate-Replace Cog Wrapper
+
+This is a Cog wrapper for the [Wan2.2 Animate-Replace](https://github.com/Wan-Video/Wan2.2) model, allowing you to deploy it as a private model on Replicate.
+
+## Prerequisites
+
+- [Cog](https://github.com/replicate/cog) installed (`pip install cog`)
+- [Docker](https://docs.docker.com/get-docker/) installed and running
+- A [Replicate](https://replicate.com) account
+
+## Building and Pushing to Replicate
+
+1. **Build the Docker image locally (optional, for testing):**
+   ```bash
+   cog build -t wan2.2-animate-replace
+   ```
+
+2. **Push to Replicate:**
+   ```bash
+   # Log in to Replicate
+   cog login
+   
+   # Push the model
+   replicate push your-username/wan2-2-animate-replace
+   ```
+
+3. **Use the model:**
+   Once pushed, you can use the model via the Replicate API or in ComfyUI with the Replicate node.
+
+## Input Parameters
+
+- `character_image`: Input image of the character to animate
+- `driving_video`: Driving video to animate the character with
+- `seed`: Random seed (default: 42)
+- `steps`: Number of animation steps (default: 50)
+- `guidance_scale`: Guidance scale (default: 3.5)
+- `width`: Output width (default: 512)
+- `height`: Output height (default: 512)
+- `num_inference_steps`: Number of denoising steps (default: 30)
+- `fps`: Frames per second of the output video (default: 30)
+
+## Example API Usage
+
+```python
+import replicate
+
+output = replicate.run(
+    "your-username/wan2-2-animate-replace:version",
+    input={
+        "character_image": "path/to/character.png",
+        "driving_video": "path/to/driving.mp4",
+        "seed": 42,
+        "steps": 50,
+        "guidance_scale": 3.5,
+        "width": 512,
+        "height": 512,
+        "num_inference_steps": 30,
+        "fps": 30
+    }
+)
+```
+
+## Hardware Requirements
+
+- GPU with at least 16GB VRAM (A100 or similar recommended)
+- 16GB+ RAM
+- 20GB+ disk space for the model and dependencies
+
+## License
+
+This wrapper is provided under the MIT License. The underlying Wan2.2 model has its own license - please refer to the [original repository](https://github.com/Wan-Video/Wan2.2) for details.

--- a/wan2.2-animate-replace/cog.yaml
+++ b/wan2.2-animate-replace/cog.yaml
@@ -1,0 +1,38 @@
+build:
+  gpu: true
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+    - "libsm6"
+    - "libxext6"
+    - "libxrender-dev"
+    - "ffmpeg"
+  python_version: "3.10"
+  python_packages:
+    - "torch==2.1.0"
+    - "torchvision==0.16.0"
+    - "torchaudio==2.1.0"
+    - "opencv-python-headless==4.8.0.76"
+    - "numpy>=1.21.0"
+    - "tqdm"
+    - "pillow>=9.0.0"
+    - "av"
+    - "einops"
+    - "omegaconf"
+    - "imageio"
+    - "imageio-ffmpeg"
+    - "gradio"
+    - "replicate"
+    - "cog"
+  run:
+    - "git clone https://github.com/Wan-Video/Wan2.2.git /src/Wan2.2"
+    - "cd /src/Wan2.2 && pip install -r requirements.txt"
+    - "mkdir -p /src/checkpoints"
+    - "wget https://huggingface.co/WanVideo/Wan2.2/resolve/main/checkpoints/wan2.2_animate_replace.ckpt -O /src/checkpoints/wan2.2_animate_replace.ckpt"
+
+predict: "predict.py:Predictor"
+
+environment:
+  PYTHONPATH: "/src/Wan2.2"
+
+devices: ["gpu"]

--- a/wan2.2-animate-replace/predict.py
+++ b/wan2.2-animate-replace/predict.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import torch
+import numpy as np
+import tempfile
+from pathlib import Path
+from typing import Optional
+import cv2
+from PIL import Image
+import torchvision.transforms as transforms
+
+# Add Wan2.2 to path
+sys.path.append('/src/Wan2.2')
+from inference.inference_animate_replace import animate_replace
+
+class Predictor:
+    def __init__(self):
+        """Load the model into memory to make running multiple predictions efficient"""
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.checkpoint_path = "/src/checkpoints/wan2.2_animate_replace.ckpt"
+        
+        # Verify checkpoint exists
+        if not os.path.exists(self.checkpoint_path):
+            raise FileNotFoundError(f"Checkpoint not found at {self.checkpoint_path}")
+
+    def predict(
+        self,
+        character_image: str,
+        driving_video: str,
+        seed: Optional[int] = 42,
+        steps: int = 50,
+        guidance_scale: float = 3.5,
+        width: int = 512,
+        height: int = 512,
+        num_inference_steps: int = 30,
+        fps: int = 30,
+    ) -> str:
+        """Run a single prediction on the model"""
+        # Set random seed for reproducibility
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        
+        # Create temporary directory for outputs
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "output.mp4")
+            
+            # Run the animation
+            try:
+                animate_replace(
+                    checkpoint_path=self.checkpoint_path,
+                    character_image=character_image,
+                    driving_video=driving_video,
+                    output_path=output_path,
+                    steps=steps,
+                    guidance_scale=guidance_scale,
+                    width=width,
+                    height=height,
+                    num_inference_steps=num_inference_steps,
+                    fps=fps,
+                    device=self.device,
+                )
+                
+                # Verify output was created
+                if not os.path.exists(output_path):
+                    raise Exception("Output video was not generated")
+                
+                # Return the output file path
+                return output_path
+                
+            except Exception as e:
+                print(f"Error during prediction: {str(e)}")
+                raise
+
+    def cleanup(self):
+        """Cleanup any resources if needed"""
+        pass


### PR DESCRIPTION
The zone identifiers weren't necessary and causing issues with Windows systems due to the ":" that the filesystem cannot read. This removes those files.